### PR TITLE
Space saving for trinket: tiny hello world 4,074-> 3498 bytes with same behavior

### DIFF
--- a/Adafruit_TinyMCP23017.cpp
+++ b/Adafruit_TinyMCP23017.cpp
@@ -1,13 +1,13 @@
-/*************************************************** 
+/***************************************************
   This is a library for the MCP23017 i2c port expander
 
-  These displays use I2C to communicate, 2 pins are required to  
+  These displays use I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -16,12 +16,12 @@
 #include "Adafruit_TinyMCP23017.h"
 
 #if ARDUINO >= 100
- #include "Arduino.h"
+  #include "Arduino.h"
 #else
- #include "WProgram.h"
+  #include "WProgram.h"
 #endif
 
-// minihelper
+ // minihelper
 static inline void wiresend(uint8_t x) {
 #if ARDUINO >= 100
   TinyWireM.write((uint8_t)x);
@@ -45,14 +45,14 @@ void Adafruit_TinyMCP23017::begin(uint8_t addr) {
   i2caddr = MCP23017_ADDRESS | addr;
 
   TinyWireM.begin();
-  
+
   // set defaults! IODIRB is 1 greater than IODIRA
   for (uint8_t port = 0; port < 2; port++)
   {
-	  TinyWireM.beginTransmission(i2caddr);
-	  wiresend(MCP23017_IODIRA + port);
-	  wiresend(0xFF);
-	  TinyWireM.endTransmission();
+    TinyWireM.beginTransmission(i2caddr);
+    wiresend(MCP23017_IODIRA + port);
+    wiresend(0xFF);
+    TinyWireM.endTransmission();
   }
 }
 
@@ -74,23 +74,24 @@ void Adafruit_TinyMCP23017::pinMode(uint8_t p, uint8_t d) {
 
   // read the current IODIR
   TinyWireM.beginTransmission(i2caddr);
-  wiresend(iodiraddr);	
+  wiresend(iodiraddr);
   TinyWireM.endTransmission();
-  
+
   TinyWireM.requestFrom(i2caddr, 1);
   iodir = wirerecv();
 
   // set the pin and direction
   if (d == INPUT) {
-    iodir |= 1 << p; 
-  } else {
+    iodir |= 1 << p;
+  }
+  else {
     iodir &= ~(1 << p);
   }
 
   // write the new IODIR
   TinyWireM.beginTransmission(i2caddr);
   wiresend(iodiraddr);
-  wiresend(iodir);	
+  wiresend(iodir);
   TinyWireM.endTransmission();
 }
 
@@ -100,9 +101,9 @@ uint16_t Adafruit_TinyMCP23017::readGPIOAB() {
 
   // read the current GPIO output latches
   TinyWireM.beginTransmission(i2caddr);
-  wiresend(MCP23017_GPIOA);	
+  wiresend(MCP23017_GPIOA);
   TinyWireM.endTransmission();
-  
+
   TinyWireM.requestFrom(i2caddr, 2);
   a = wirerecv();
   ba = wirerecv();
@@ -114,51 +115,53 @@ uint16_t Adafruit_TinyMCP23017::readGPIOAB() {
 
 void Adafruit_TinyMCP23017::writeGPIOAB(uint16_t ba) {
   TinyWireM.beginTransmission(i2caddr);
-  wiresend(MCP23017_GPIOA);	
+  wiresend(MCP23017_GPIOA);
   wiresend(ba & 0xFF);
   wiresend(ba >> 8);
   TinyWireM.endTransmission();
 }
 
-void Adafruit_TinyMCP23017::digitalWrite(uint8_t p, uint8_t d) {
+void Adafruit_TinyMCP23017::digitalWrite(uint8_t pin, uint8_t direction) {
   uint8_t gpio;
   uint8_t gpioaddr, olataddr;
 
   olataddr = MCP23017_OLATA;
-  if (p >= 8) {
-	olataddr = MCP23017_OLATB;
-	p -= 8;
+  if (pin >= 8) {
+    olataddr = MCP23017_OLATB;
+    pin -= 8;
   }
   gpioaddr = olataddr - 2;
 
   // read the current GPIO output latches
   TinyWireM.beginTransmission(i2caddr);
-  wiresend(olataddr);	
+  wiresend(olataddr);
   TinyWireM.endTransmission();
-  
+
   TinyWireM.requestFrom(i2caddr, 1);
-   gpio = wirerecv();
+  gpio = wirerecv();
 
   // set the pin and direction
-  if (d == HIGH) {
-    gpio |= 1 << p; 
-  } else {
-    gpio &= ~(1 << p);
+  if (direction == HIGH) {
+    gpio |= 1 << pin;
+  }
+  else {
+    gpio &= ~(1 << pin);
   }
 
   // write the new GPIO
   TinyWireM.beginTransmission(i2caddr);
   wiresend(gpioaddr);
-  wiresend(gpio);	
+  wiresend(gpio);
   TinyWireM.endTransmission();
 }
 
-void Adafruit_TinyMCP23017::pullUp(uint8_t p, uint8_t d) {
+void Adafruit_TinyMCP23017::pullUp(uint8_t p, uint8_t direction) {
   uint8_t gppu;
   uint8_t gppuaddr;
 
-  if (p < 8)
+  if (p < 8) {
     gppuaddr = MCP23017_GPPUA;
+  }
   else {
     gppuaddr = MCP23017_GPPUB;
     p -= 8;
@@ -167,23 +170,24 @@ void Adafruit_TinyMCP23017::pullUp(uint8_t p, uint8_t d) {
 
   // read the current pullup resistor set
   TinyWireM.beginTransmission(i2caddr);
-  wiresend(gppuaddr);	
+  wiresend(gppuaddr);
   TinyWireM.endTransmission();
-  
+
   TinyWireM.requestFrom(i2caddr, 1);
   gppu = wirerecv();
 
   // set the pin and direction
-  if (d == HIGH) {
-    gppu |= 1 << p; 
-  } else {
+  if (direction == HIGH) {
+    gppu |= 1 << p;
+  }
+  else {
     gppu &= ~(1 << p);
   }
 
   // write the new GPIO
   TinyWireM.beginTransmission(i2caddr);
   wiresend(gppuaddr);
-  wiresend(gppu);	
+  wiresend(gppu);
   TinyWireM.endTransmission();
 }
 
@@ -191,7 +195,9 @@ uint8_t Adafruit_TinyMCP23017::digitalRead(uint8_t p) {
   uint8_t gpioaddr;
 
   if (p < 8)
+  {
     gpioaddr = MCP23017_GPIOA;
+  }
   else {
     gpioaddr = MCP23017_GPIOB;
     p -= 8;
@@ -199,9 +205,9 @@ uint8_t Adafruit_TinyMCP23017::digitalRead(uint8_t p) {
 
   // read the current GPIO
   TinyWireM.beginTransmission(i2caddr);
-  wiresend(gpioaddr);	
+  wiresend(gpioaddr);
   TinyWireM.endTransmission();
-  
+
   TinyWireM.requestFrom(i2caddr, 1);
   return (wirerecv() >> p) & 0x1;
 }

--- a/Adafruit_TinyRGBLCDShield.cpp
+++ b/Adafruit_TinyRGBLCDShield.cpp
@@ -1,15 +1,15 @@
-/*************************************************** 
-  This is a library for the Adafruit RGB 16x2 LCD Shield 
+/***************************************************
+  This is a library for the Adafruit RGB 16x2 LCD Shield
   Pick one up at the Adafruit shop!
   ---------> http://http://www.adafruit.com/products/714
 
-  The shield uses I2C to communicate, 2 pins are required to  
+  The shield uses I2C to communicate, 2 pins are required to
   interface
-  Adafruit invests time and resources providing this open source code, 
-  please support Adafruit and open-source hardware by purchasing 
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
   products from Adafruit!
 
-  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  Written by Limor Fried/Ladyada for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
@@ -22,300 +22,298 @@
 #include <TinyWireM.h>
 
 #if ARDUINO >= 100
- #include "Arduino.h"
+#include "Arduino.h"
 #else
- #include "WProgram.h"
+#include "WProgram.h"
 #endif
 
-// When the display powers up, it is configured as follows:
-//
-// 1. Display clear
-// 2. Function set: 
-//    DL = 1; 8-bit interface data 
-//    N = 0; 1-line display 
-//    F = 0; 5x8 dot character font 
-// 3. Display on/off control: 
-//    D = 0; Display off 
-//    C = 0; Cursor off 
-//    B = 0; Blinking off 
-// 4. Entry mode set: 
-//    I/D = 1; Increment by 1 
-//    S = 0; No shift 
-//
-// Note, however, that resetting the Arduino doesn't reset the LCD, so we
-// can't assume that its in that state when a sketch starts (and the
-// RGBLCDShield constructor is called).
+ // When the display powers up, it is configured as follows:
+ //
+ // 1. Display clear
+ // 2. Function set: 
+ //    DL = 1; 8-bit interface data 
+ //    N = 0; 1-line display 
+ //    F = 0; 5x8 dot character font 
+ // 3. Display on/off control: 
+ //    D = 0; Display off 
+ //    C = 0; Cursor off 
+ //    B = 0; Blinking off 
+ // 4. Entry mode set: 
+ //    I/D = 1; Increment by 1 
+ //    S = 0; No shift 
+ //
+ // Note, however, that resetting the Arduino doesn't reset the LCD, so we
+ // can't assume that its in that state when a sketch starts (and the
+ // RGBLCDShield constructor is called).
 
 Adafruit_TinyRGBLCDShield::Adafruit_TinyRGBLCDShield() {
-  _i2cAddr = 0;
+	_i2cAddr = 0;
 
-  _displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
-  
-  // the I/O expander pinout
-  _rs_pin = 15;
-  _rw_pin = 14;
-  _enable_pin = 13;
+	_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
 
-  _data_pins[0] = 12;  // really d4
-  _data_pins[1] = 11;  // really d5
-  _data_pins[2] = 10;  // really d6
-  _data_pins[3] = 9;  // really d7
-  
-  _button_pins[0] = 0;
-  _button_pins[1] = 1;
-  _button_pins[2] = 2;
-  _button_pins[3] = 3;
-  _button_pins[4] = 4;
-  // we can't begin() yet :(
+	// the I/O expander pinout
+	_rs_pin = 15;
+	_rw_pin = 14;
+	_enable_pin = 13;
+
+	_data_pins[0] = 12;  // really d4
+	_data_pins[1] = 11;  // really d5
+	_data_pins[2] = 10;  // really d6
+	_data_pins[3] = 9;  // really d7
+
+	_button_pins[0] = 0;
+	_button_pins[1] = 1;
+	_button_pins[2] = 2;
+	_button_pins[3] = 3;
+	_button_pins[4] = 4;
+	// we can't begin() yet :(
 }
 
 
 
 
 void Adafruit_TinyRGBLCDShield::init(uint8_t fourbitmode, uint8_t rs, uint8_t rw, uint8_t enable,
-			 uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
-			 uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
+	uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+	uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
 {
-  _rs_pin = rs;
-  _rw_pin = rw;
-  _enable_pin = enable;
-  
-  _data_pins[0] = d0;
-  _data_pins[1] = d1;
-  _data_pins[2] = d2;
-  _data_pins[3] = d3; 
-  _data_pins[4] = d4;
-  _data_pins[5] = d5;
-  _data_pins[6] = d6;
-  _data_pins[7] = d7; 
+	_rs_pin = rs;
+	_rw_pin = rw;
+	_enable_pin = enable;
 
-  _i2cAddr = 255;
+	_data_pins[0] = d0;
+	_data_pins[1] = d1;
+	_data_pins[2] = d2;
+	_data_pins[3] = d3;
+	_data_pins[4] = d4;
+	_data_pins[5] = d5;
+	_data_pins[6] = d6;
+	_data_pins[7] = d7;
 
-  _pinMode(_rs_pin, OUTPUT);
-  // we can save 1 pin by not using RW. Indicate by passing 255 instead of pin#
-  if (_rw_pin != 255) { 
-    _pinMode(_rw_pin, OUTPUT);
-  }
-  _pinMode(_enable_pin, OUTPUT);
-  
+	_i2cAddr = 255;
 
-  if (fourbitmode)
-    _displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
-  else 
-    _displayfunction = LCD_8BITMODE | LCD_1LINE | LCD_5x8DOTS;
-  
-  begin(16, 1);  
+	_pinMode(_rs_pin, OUTPUT);
+	// we can save 1 pin by not using RW. Indicate by passing 255 instead of pin#
+	if (_rw_pin != 255) {
+		_pinMode(_rw_pin, OUTPUT);
+	}
+	_pinMode(_enable_pin, OUTPUT);
+
+
+	if (fourbitmode)
+		_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
+	else
+		_displayfunction = LCD_8BITMODE | LCD_1LINE | LCD_5x8DOTS;
+
+	begin(16, 1);
 }
 
 void Adafruit_TinyRGBLCDShield::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
-  // check if i2c
-  if (_i2cAddr != 255) {
-    //_i2c.begin(_i2cAddr);
-    TinyWireM.begin();
-    _i2c.begin();
+	// check if i2c
+	if (_i2cAddr != 255) {
+		//_i2c.begin(_i2cAddr);
+		TinyWireM.begin();
+		_i2c.begin();
 
-    _i2c.pinMode(8, OUTPUT);
-    _i2c.pinMode(6, OUTPUT);
-    _i2c.pinMode(7, OUTPUT);
-    setBacklight(0x7);
+		_i2c.pinMode(8, OUTPUT);
+		_i2c.pinMode(6, OUTPUT);
+		_i2c.pinMode(7, OUTPUT);
+		setBacklight(0x7);
 
-    if (_rw_pin)
-      _i2c.pinMode(_rw_pin, OUTPUT);
+		if (_rw_pin)
+			_i2c.pinMode(_rw_pin, OUTPUT);
 
-    _i2c.pinMode(_rs_pin, OUTPUT);
-    _i2c.pinMode(_enable_pin, OUTPUT);
+		_i2c.pinMode(_rs_pin, OUTPUT);
+		_i2c.pinMode(_enable_pin, OUTPUT);
 
-    for (uint8_t i=0; i<5; i++) {
-      _i2c.pinMode(_data_pins[i & 0x4], OUTPUT);
-      _i2c.pinMode(_button_pins[i], INPUT);
-      _i2c.pullUp(_button_pins[i], 1);
-    }
-  }
+		for (uint8_t i = 0; i < 5; i++) {
+			_i2c.pinMode(_data_pins[i & 0x4], OUTPUT);
+			_i2c.pinMode(_button_pins[i], INPUT);
+			_i2c.pullUp(_button_pins[i], 1);
+		}
+	}
 
-  if (lines > 1) {
-    _displayfunction |= LCD_2LINE;
-  }
-  _numlines = lines;
-  _currline = 0;
+	if (lines > 1) {
+		_displayfunction |= LCD_2LINE;
+	}
+	_numlines = lines;
+	_currline = 0;
 
-  // for some 1 line displays you can select a 10 pixel high font
-  if ((dotsize != 0) && (lines == 1)) {
-    _displayfunction |= LCD_5x10DOTS;
-  }
+	// for some 1 line displays you can select a 10 pixel high font
+	if ((dotsize != 0) && (lines == 1)) {
+		_displayfunction |= LCD_5x10DOTS;
+	}
 
-  // SEE PAGE 45/46 FOR INITIALIZATION SPECIFICATION!
-  // according to datasheet, we need at least 40ms after power rises above 2.7V
-  // before sending commands. Arduino can turn on way befer 4.5V so we'll wait 50
-  delayMicroseconds(50000); 
-  // Now we pull both RS and R/W low to begin commands
-  _digitalWrite(_rs_pin, LOW);
-  _digitalWrite(_enable_pin, LOW);
-  if (_rw_pin != 255) { 
-    _digitalWrite(_rw_pin, LOW);
-  }
-  
-  //put the LCD into 4 bit or 8 bit mode
-  if (! (_displayfunction & LCD_8BITMODE)) {
-    // this is according to the hitachi HD44780 datasheet
-    // figure 24, pg 46
+	// SEE PAGE 45/46 FOR INITIALIZATION SPECIFICATION!
+	// according to datasheet, we need at least 40ms after power rises above 2.7V
+	// before sending commands. Arduino can turn on way befer 4.5V so we'll wait 50
+	delayMicroseconds(50000);
+	// Now we pull both RS and R/W low to begin commands
+	_digitalWrite(_rs_pin, LOW);
+	_digitalWrite(_enable_pin, LOW);
+	if (_rw_pin != 255) {
+		_digitalWrite(_rw_pin, LOW);
+	}
 
-    // we start in 8bit mode, try to set 4 bit mode
-    write4bits(0x03);
-    delayMicroseconds(4500); // wait min 4.1ms
+	//put the LCD into 4 bit or 8 bit mode
+	if (!(_displayfunction & LCD_8BITMODE)) {
+		// this is according to the hitachi HD44780 datasheet
+		// figure 24, pg 46
 
-    // second try
-    write4bits(0x03);
-    delayMicroseconds(4500); // wait min 4.1ms
-    
-    // third go!
-    write4bits(0x03); 
-    delayMicroseconds(150);
+		// we start in 8bit mode, try to set 4 bit mode
+		for (int i = 0; i < 3; i++)
+		{
+			// 3 tries to wake up, minimum 4.1ms wait between
+			write4bits(0x03);
+			delayMicroseconds(4500);
+		}
 
-    // finally, set to 8-bit interface
-    write4bits(0x02); 
-  } else {
-    // this is according to the hitachi HD44780 datasheet
-    // page 45 figure 23
+		// finally, set to 8-bit interface
+		write4bits(0x02);
 
-    // Send function set command sequence
-    command(LCD_FUNCTIONSET | _displayfunction);
-    delayMicroseconds(4500);  // wait more than 4.1ms
+	}
+	else {
+		// this is according to the hitachi HD44780 datasheet
+		// page 45 figure 23
 
-    // second try
-    command(LCD_FUNCTIONSET | _displayfunction);
-    delayMicroseconds(150);
+		// Send function set command sequence
+		command(LCD_FUNCTIONSET | _displayfunction);
+		delayMicroseconds(4500);  // wait more than 4.1ms
 
-    // third go
-    command(LCD_FUNCTIONSET | _displayfunction);
-  }
+		// second try
+		command(LCD_FUNCTIONSET | _displayfunction);
+		delayMicroseconds(150);
 
-  // finally, set # lines, font size, etc.
-  command(LCD_FUNCTIONSET | _displayfunction);  
+		// third go
+		command(LCD_FUNCTIONSET | _displayfunction);
+	}
 
-  // turn the display on with no cursor or blinking default
-  _displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;  
-  display();
+	// finally, set # lines, font size, etc.
+	command(LCD_FUNCTIONSET | _displayfunction);
 
-  // clear it off
-  clear();
+	// turn the display on with no cursor or blinking default
+	_displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
+	display();
 
-  // Initialize to default text direction (for romance languages)
-  _displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
-  // set the entry mode
-  command(LCD_ENTRYMODESET | _displaymode);
+	// clear it off
+	clear();
+
+	// Initialize to default text direction (for romance languages)
+	_displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
+	// set the entry mode
+	command(LCD_ENTRYMODESET | _displaymode);
 
 }
 
 /********** high level commands, for the user! */
 void Adafruit_TinyRGBLCDShield::clear()
 {
-  command(LCD_CLEARDISPLAY);  // clear display, set cursor position to zero
-  delayMicroseconds(2000);  // this command takes a long time!
+	command(LCD_CLEARDISPLAY);  // clear display, set cursor position to zero
+	delayMicroseconds(2000);  // this command takes a long time!
 }
 
 void Adafruit_TinyRGBLCDShield::home()
 {
-  command(LCD_RETURNHOME);  // set cursor position to zero
-  delayMicroseconds(2000);  // this command takes a long time!
+	command(LCD_RETURNHOME);  // set cursor position to zero
+	delayMicroseconds(2000);  // this command takes a long time!
 }
 
 void Adafruit_TinyRGBLCDShield::setCursor(uint8_t col, uint8_t row)
 {
-  int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
-  if ( row > _numlines ) {
-    row = _numlines-1;    // we count rows starting w/0
-  }
-  
-  command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
+	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
+	if (row > _numlines) {
+		row = _numlines - 1;    // we count rows starting w/0
+	}
+
+	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
 }
 
 // Turn the display on/off (quickly)
 void Adafruit_TinyRGBLCDShield::noDisplay() {
-  _displaycontrol &= ~LCD_DISPLAYON;
-  command(LCD_DISPLAYCONTROL | _displaycontrol);
+	_displaycontrol &= ~LCD_DISPLAYON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 void Adafruit_TinyRGBLCDShield::display() {
-  _displaycontrol |= LCD_DISPLAYON;
-  command(LCD_DISPLAYCONTROL | _displaycontrol);
+	_displaycontrol |= LCD_DISPLAYON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // Turns the underline cursor on/off
 void Adafruit_TinyRGBLCDShield::noCursor() {
-  _displaycontrol &= ~LCD_CURSORON;
-  command(LCD_DISPLAYCONTROL | _displaycontrol);
+	_displaycontrol &= ~LCD_CURSORON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 void Adafruit_TinyRGBLCDShield::cursor() {
-  _displaycontrol |= LCD_CURSORON;
-  command(LCD_DISPLAYCONTROL | _displaycontrol);
+	_displaycontrol |= LCD_CURSORON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // Turn on and off the blinking cursor
 void Adafruit_TinyRGBLCDShield::noBlink() {
-  _displaycontrol &= ~LCD_BLINKON;
-  command(LCD_DISPLAYCONTROL | _displaycontrol);
+	_displaycontrol &= ~LCD_BLINKON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 void Adafruit_TinyRGBLCDShield::blink() {
-  _displaycontrol |= LCD_BLINKON;
-  command(LCD_DISPLAYCONTROL | _displaycontrol);
+	_displaycontrol |= LCD_BLINKON;
+	command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // These commands scroll the display without changing the RAM
 void Adafruit_TinyRGBLCDShield::scrollDisplayLeft(void) {
-  command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
+	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
 }
 void Adafruit_TinyRGBLCDShield::scrollDisplayRight(void) {
-  command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
+	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
 }
 
 // This is for text that flows Left to Right
 void Adafruit_TinyRGBLCDShield::leftToRight(void) {
-  _displaymode |= LCD_ENTRYLEFT;
-  command(LCD_ENTRYMODESET | _displaymode);
+	_displaymode |= LCD_ENTRYLEFT;
+	command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This is for text that flows Right to Left
 void Adafruit_TinyRGBLCDShield::rightToLeft(void) {
-  _displaymode &= ~LCD_ENTRYLEFT;
-  command(LCD_ENTRYMODESET | _displaymode);
+	_displaymode &= ~LCD_ENTRYLEFT;
+	command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This will 'right justify' text from the cursor
 void Adafruit_TinyRGBLCDShield::autoscroll(void) {
-  _displaymode |= LCD_ENTRYSHIFTINCREMENT;
-  command(LCD_ENTRYMODESET | _displaymode);
+	_displaymode |= LCD_ENTRYSHIFTINCREMENT;
+	command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This will 'left justify' text from the cursor
 void Adafruit_TinyRGBLCDShield::noAutoscroll(void) {
-  _displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
-  command(LCD_ENTRYMODESET | _displaymode);
+	_displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
+	command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // Allows us to fill the first 8 CGRAM locations
 // with custom characters
 void Adafruit_TinyRGBLCDShield::createChar(uint8_t location, uint8_t charmap[]) {
-  location &= 0x7; // we only have 8 locations 0-7
-  command(LCD_SETCGRAMADDR | (location << 3));
-  for (int i=0; i<8; i++) {
-    write(charmap[i]);
-  }
-  command(LCD_SETDDRAMADDR);  // unfortunately resets the location to 0,0
+	location &= 0x7; // we only have 8 locations 0-7
+	command(LCD_SETCGRAMADDR | (location << 3));
+	for (int i = 0; i < 8; i++) {
+		write(charmap[i]);
+	}
+	command(LCD_SETDDRAMADDR);  // unfortunately resets the location to 0,0
 }
 
 /*********** mid level commands, for sending data/cmds */
 
 inline void Adafruit_TinyRGBLCDShield::command(uint8_t value) {
-  send(value, LOW);
+	send(value, LOW);
 }
 
 #if ARDUINO >= 100
 inline size_t Adafruit_TinyRGBLCDShield::write(uint8_t value) {
-  send(value, HIGH);
-  return 1;
+	send(value, HIGH);
+	return 1;
 }
 #else
 inline void Adafruit_TinyRGBLCDShield::write(uint8_t value) {
-  send(value, HIGH);
+	send(value, HIGH);
 }
 #endif
 
@@ -323,100 +321,104 @@ inline void Adafruit_TinyRGBLCDShield::write(uint8_t value) {
 
 // little wrapper for i/o writes
 void  Adafruit_TinyRGBLCDShield::_digitalWrite(uint8_t p, uint8_t d) {
-  if (_i2cAddr != 255) {
-    // an i2c command
-    _i2c.digitalWrite(p, d);
-  } else {
-    // straightup IO
-    digitalWrite(p, d);
-  }
+	if (_i2cAddr != 255) {
+		// an i2c command
+		_i2c.digitalWrite(p, d);
+	}
+	else {
+		// straightup IO
+		digitalWrite(p, d);
+	}
 }
 
 // Allows to set the backlight, if the LCD backpack is used
 void Adafruit_TinyRGBLCDShield::setBacklight(uint8_t status) {
-  // check if i2c or SPI
-  _i2c.digitalWrite(8, ~(status >> 2) & 0x1);
-  _i2c.digitalWrite(7, ~(status >> 1) & 0x1);
-  _i2c.digitalWrite(6, ~status & 0x1);
+	// check if i2c or SPI
+	_i2c.digitalWrite(8, ~(status >> 2) & 0x1);
+	_i2c.digitalWrite(7, ~(status >> 1) & 0x1);
+	_i2c.digitalWrite(6, ~status & 0x1);
 }
 
 // little wrapper for i/o directions
 void  Adafruit_TinyRGBLCDShield::_pinMode(uint8_t p, uint8_t d) {
-  if (_i2cAddr != 255) {
-    // an i2c command
-    _i2c.pinMode(p, d);
-  } else {
-    // straightup IO
-    pinMode(p, d);
-  }
+	if (_i2cAddr != 255) {
+		// an i2c command
+		_i2c.pinMode(p, d);
+	}
+	else {
+		// straightup IO
+		pinMode(p, d);
+	}
 }
 
 // write either command or data, with automatic 4/8-bit selection
 void Adafruit_TinyRGBLCDShield::send(uint8_t value, uint8_t mode) {
-  _digitalWrite(_rs_pin, mode);
+	_digitalWrite(_rs_pin, mode);
 
-  // if there is a RW pin indicated, set it low to Write
-  if (_rw_pin != 255) { 
-    _digitalWrite(_rw_pin, LOW);
-  }
-  
-  if (_displayfunction & LCD_8BITMODE) {
-    write8bits(value); 
-  } else {
-    write4bits(value>>4);
-    write4bits(value);
-  }
+	// if there is a RW pin indicated, set it low to Write
+	if (_rw_pin != 255) {
+		_digitalWrite(_rw_pin, LOW);
+	}
+
+	if (_displayfunction & LCD_8BITMODE) {
+		write8bits(value);
+	}
+	else {
+		write4bits(value >> 4);
+		write4bits(value);
+	}
 }
 
 void Adafruit_TinyRGBLCDShield::pulseEnable(void) {
-  _digitalWrite(_enable_pin, LOW);
-  delayMicroseconds(1);    
-  _digitalWrite(_enable_pin, HIGH);
-  delayMicroseconds(1);    // enable pulse must be >450ns
-  _digitalWrite(_enable_pin, LOW);
-  delayMicroseconds(100);   // commands need > 37us to settle
+	_digitalWrite(_enable_pin, LOW);
+	delayMicroseconds(1);
+	_digitalWrite(_enable_pin, HIGH);
+	delayMicroseconds(1);    // enable pulse must be >450ns
+	_digitalWrite(_enable_pin, LOW);
+	delayMicroseconds(100);   // commands need > 37us to settle
 }
 
 void Adafruit_TinyRGBLCDShield::writeBits(uint8_t value, uint8_t length) {
-  if (length < 8 && _i2cAddr != 255) {
-    uint16_t out = 0;
+	if (length < 8 && _i2cAddr != 255) {
+		uint16_t out = 0;
 
-    out = _i2c.readGPIOAB();
+		out = _i2c.readGPIOAB();
 
-    // speed up for i2c since its sluggish
-    for (int i = 0; i < 4; i++) {
-      out &= ~_BV(_data_pins[i]);
-      out |= ((value >> i) & 0x1) << _data_pins[i];
-    }
+		// speed up for i2c since its sluggish
+		for (int i = 0; i < 4; i++) {
+			out &= ~_BV(_data_pins[i]);
+			out |= ((value >> i) & 0x1) << _data_pins[i];
+		}
 
-    // make sure enable is low
-    out &= ~ _BV(_enable_pin);
+		// make sure enable is low
+		out &= ~_BV(_enable_pin);
 
-    _i2c.writeGPIOAB(out);
+		_i2c.writeGPIOAB(out);
 
-    // pulse enable
-    delayMicroseconds(1);
-    out |= _BV(_enable_pin);
-    _i2c.writeGPIOAB(out);
-    delayMicroseconds(1);
-    out &= ~_BV(_enable_pin);
-    _i2c.writeGPIOAB(out);   
-    delayMicroseconds(100);
+		// pulse enable
+		delayMicroseconds(1);
+		out |= _BV(_enable_pin);
+		_i2c.writeGPIOAB(out);
+		delayMicroseconds(1);
+		out &= ~_BV(_enable_pin);
+		_i2c.writeGPIOAB(out);
+		delayMicroseconds(100);
 
-  } else {
-    for (int i = 0; i < length; i++) {
-     _pinMode(_data_pins[i], OUTPUT);
-     _digitalWrite(_data_pins[i], (value >> i) & 0x01);
-    }
-    pulseEnable();
-  }
+	}
+	else {
+		for (int i = 0; i < length; i++) {
+			_pinMode(_data_pins[i], OUTPUT);
+			_digitalWrite(_data_pins[i], (value >> i) & 0x01);
+		}
+		pulseEnable();
+	}
 }
 
 uint8_t Adafruit_TinyRGBLCDShield::readButtons(void) {
-  uint8_t reply = 0x1F;
+	uint8_t reply = 0x1F;
 
-  for (uint8_t i=0; i<5; i++) {
-    reply &= ~((_i2c.digitalRead(_button_pins[i])) << i);
-  }
-  return reply;
+	for (uint8_t i = 0; i < 5; i++) {
+		reply &= ~((_i2c.digitalRead(_button_pins[i])) << i);
+	}
+	return reply;
 }

--- a/Adafruit_TinyRGBLCDShield.cpp
+++ b/Adafruit_TinyRGBLCDShield.cpp
@@ -47,273 +47,256 @@
  // RGBLCDShield constructor is called).
 
 Adafruit_TinyRGBLCDShield::Adafruit_TinyRGBLCDShield() {
-	_i2cAddr = 0;
+  _i2cAddr = 0;
 
-	_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
+  _displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
 
-	// the I/O expander pinout
-	_rs_pin = 15;
-	_rw_pin = 14;
-	_enable_pin = 13;
+  // the I/O expander pinout
+  _rs_pin = 15;
+  _rw_pin = 14;
+  _enable_pin = 13;
 
-	_data_pins[0] = 12;  // really d4
-	_data_pins[1] = 11;  // really d5
-	_data_pins[2] = 10;  // really d6
-	_data_pins[3] = 9;  // really d7
+  _data_pins[0] = 12;  // really d4
+  _data_pins[1] = 11;  // really d5
+  _data_pins[2] = 10;  // really d6
+  _data_pins[3] = 9;  // really d7
 
-	_button_pins[0] = 0;
-	_button_pins[1] = 1;
-	_button_pins[2] = 2;
-	_button_pins[3] = 3;
-	_button_pins[4] = 4;
-	// we can't begin() yet :(
+  _button_pins[0] = 0;
+  _button_pins[1] = 1;
+  _button_pins[2] = 2;
+  _button_pins[3] = 3;
+  _button_pins[4] = 4;
+  // we can't begin() yet :(
 }
 
 
 
 
-void Adafruit_TinyRGBLCDShield::init(uint8_t fourbitmode, uint8_t rs, uint8_t rw, uint8_t enable,
-	uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
-	uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
+void Adafruit_TinyRGBLCDShield::init(uint8_t mode, uint8_t rs, uint8_t rw, uint8_t enable,
+  uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3,
+  uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7)
 {
-	_rs_pin = rs;
-	_rw_pin = rw;
-	_enable_pin = enable;
+  _rs_pin = rs;
+  _rw_pin = rw;
+  _enable_pin = enable;
 
-	_data_pins[0] = d0;
-	_data_pins[1] = d1;
-	_data_pins[2] = d2;
-	_data_pins[3] = d3;
-	_data_pins[4] = d4;
-	_data_pins[5] = d5;
-	_data_pins[6] = d6;
-	_data_pins[7] = d7;
+  _data_pins[0] = d0;
+  _data_pins[1] = d1;
+  _data_pins[2] = d2;
+  _data_pins[3] = d3;
+  _data_pins[4] = d4;
+  _data_pins[5] = d5;
+  _data_pins[6] = d6;
+  _data_pins[7] = d7;
 
-	_i2cAddr = 255;
+  _i2cAddr = 255;
 
-	_pinMode(_rs_pin, OUTPUT);
-	// we can save 1 pin by not using RW. Indicate by passing 255 instead of pin#
-	if (_rw_pin != 255) {
-		_pinMode(_rw_pin, OUTPUT);
-	}
-	_pinMode(_enable_pin, OUTPUT);
+  _pinMode(_rs_pin, OUTPUT);
+  // we can save 1 pin by not using RW. Enable RW mode using #define LCD_RW before including
+#if defined(LCD_RW)
+  _pinMode(_rw_pin, OUTPUT);
+#endif
+  _pinMode(_enable_pin, OUTPUT);
 
+  _displayfunction = mode | LCD_1LINE | LCD_5x8DOTS;
 
-	if (fourbitmode)
-		_displayfunction = LCD_4BITMODE | LCD_1LINE | LCD_5x8DOTS;
-	else
-		_displayfunction = LCD_8BITMODE | LCD_1LINE | LCD_5x8DOTS;
-
-	begin(16, 1);
+  begin(16, 1);
 }
 
 void Adafruit_TinyRGBLCDShield::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
-	// check if i2c
-	if (_i2cAddr != 255) {
-		//_i2c.begin(_i2cAddr);
-		TinyWireM.begin();
-		_i2c.begin();
+  // check if i2c
+  if (_i2cAddr != 255) {
+    //_i2c.begin(_i2cAddr);
+    TinyWireM.begin();
+    _i2c.begin();
 
-		_i2c.pinMode(8, OUTPUT);
-		_i2c.pinMode(6, OUTPUT);
-		_i2c.pinMode(7, OUTPUT);
-		setBacklight(0x7);
+    _i2c.pinMode(8, OUTPUT);
+    _i2c.pinMode(6, OUTPUT);
+    _i2c.pinMode(7, OUTPUT);
+    setBacklight(0x7);
 
-		if (_rw_pin)
-			_i2c.pinMode(_rw_pin, OUTPUT);
+    if (_rw_pin) {
+      _i2c.pinMode(_rw_pin, OUTPUT);
+    }
 
-		_i2c.pinMode(_rs_pin, OUTPUT);
-		_i2c.pinMode(_enable_pin, OUTPUT);
+    _i2c.pinMode(_rs_pin, OUTPUT);
+    _i2c.pinMode(_enable_pin, OUTPUT);
 
-		for (uint8_t i = 0; i < 5; i++) {
-			_i2c.pinMode(_data_pins[i & 0x4], OUTPUT);
-			_i2c.pinMode(_button_pins[i], INPUT);
-			_i2c.pullUp(_button_pins[i], 1);
-		}
-	}
+    for (uint8_t i = 0; i < 5; i++) {
+      _i2c.pinMode(_data_pins[i % 0x4], OUTPUT);
+      _i2c.pinMode(_button_pins[i], INPUT);
+      _i2c.pullUp(_button_pins[i], 1);
+    }
+  }
 
-	if (lines > 1) {
-		_displayfunction |= LCD_2LINE;
-	}
-	_numlines = lines;
-	_currline = 0;
+  if (lines > 1) {
+    _displayfunction |= LCD_2LINE;
+  }
+  // for some 1 line displays you can select a 10 pixel high font
+  else if (dotsize != 0) {
+    _displayfunction |= LCD_5x10DOTS;
+  }
 
-	// for some 1 line displays you can select a 10 pixel high font
-	if ((dotsize != 0) && (lines == 1)) {
-		_displayfunction |= LCD_5x10DOTS;
-	}
+  _numlines = lines;
+  _currline = 0;
 
-	// SEE PAGE 45/46 FOR INITIALIZATION SPECIFICATION!
-	// according to datasheet, we need at least 40ms after power rises above 2.7V
-	// before sending commands. Arduino can turn on way befer 4.5V so we'll wait 50
-	delayMicroseconds(50000);
-	// Now we pull both RS and R/W low to begin commands
-	_digitalWrite(_rs_pin, LOW);
-	_digitalWrite(_enable_pin, LOW);
-	if (_rw_pin != 255) {
-		_digitalWrite(_rw_pin, LOW);
-	}
+  // SEE PAGE 45/46 OF THE HITACHI HD44780 DATASHEET FOR INITIALIZATION SPECIFICATION!
+  // Wait at least 40ms after power rises above 2.7V and 15ms after power rises above 4.5V before sending commands. 
+  // Arduino can turn on way before 4.5V, so wait 50ms.
+  delayMicroseconds(50000);
 
-	//put the LCD into 4 bit or 8 bit mode
-	if (!(_displayfunction & LCD_8BITMODE)) {
-		// this is according to the hitachi HD44780 datasheet
-		// figure 24, pg 46
+  // Pull both RS and R/W low to begin commands
+  _digitalWrite(_rs_pin, LOW);
+  _digitalWrite(_enable_pin, LOW);
 
-		// we start in 8bit mode, try to set 4 bit mode
-		for (int i = 0; i < 3; i++)
-		{
-			// 3 tries to wake up, minimum 4.1ms wait between
-			write4bits(0x03);
-			delayMicroseconds(4500);
-		}
+#if defined(LCD_RW)
+  _digitalWrite(_rw_pin, LOW);
+#endif
 
-		// finally, set to 8-bit interface
-		write4bits(0x02);
+  // put the LCD into 4 bit or 8 bit mode
+  for (int i = 0; i < 3; i++)
+  {
+#if defined(LCD_8BIT)
+    command(LCD_FUNCTIONSET | _displayfunction);
+#else
+    // 3 tries to wake up, longest minimum wait is 4.1ms, use that for every wait
+    writeBits(0x03);
+#endif
+    delayMicroseconds(4500);
+  }
 
-	}
-	else {
-		// this is according to the hitachi HD44780 datasheet
-		// page 45 figure 23
+#if !defined(LCD_8BIT)
+  // set to 4-bit interface
+  writeBits(0x02);
+#endif
 
-		// Send function set command sequence
-		command(LCD_FUNCTIONSET | _displayfunction);
-		delayMicroseconds(4500);  // wait more than 4.1ms
+  // finally, set # lines, font size, etc.
+  command(LCD_FUNCTIONSET | _displayfunction);
 
-		// second try
-		command(LCD_FUNCTIONSET | _displayfunction);
-		delayMicroseconds(150);
+  // turn the display on with no cursor or blinking default
+  _displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
+  display();
 
-		// third go
-		command(LCD_FUNCTIONSET | _displayfunction);
-	}
+  // clear it off
+  clear();
 
-	// finally, set # lines, font size, etc.
-	command(LCD_FUNCTIONSET | _displayfunction);
-
-	// turn the display on with no cursor or blinking default
-	_displaycontrol = LCD_DISPLAYON | LCD_CURSOROFF | LCD_BLINKOFF;
-	display();
-
-	// clear it off
-	clear();
-
-	// Initialize to default text direction (for romance languages)
-	_displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
-	// set the entry mode
-	command(LCD_ENTRYMODESET | _displaymode);
+  // Initialize to default text direction (for romance languages)
+  _displaymode = LCD_ENTRYLEFT | LCD_ENTRYSHIFTDECREMENT;
+  // set the entry mode
+  command(LCD_ENTRYMODESET | _displaymode);
 
 }
 
 /********** high level commands, for the user! */
 void Adafruit_TinyRGBLCDShield::clear()
 {
-	command(LCD_CLEARDISPLAY);  // clear display, set cursor position to zero
-	delayMicroseconds(2000);  // this command takes a long time!
+  command(LCD_CLEARDISPLAY);  // clear display, set cursor position to zero
+  delayMicroseconds(2000);  // this command takes a long time!
 }
 
 void Adafruit_TinyRGBLCDShield::home()
 {
-	command(LCD_RETURNHOME);  // set cursor position to zero
-	delayMicroseconds(2000);  // this command takes a long time!
+  command(LCD_RETURNHOME);  // set cursor position to zero
+  delayMicroseconds(2000);  // this command takes a long time!
 }
 
 void Adafruit_TinyRGBLCDShield::setCursor(uint8_t col, uint8_t row)
 {
-	int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
-	if (row > _numlines) {
-		row = _numlines - 1;    // we count rows starting w/0
-	}
+  int row_offsets[] = { 0x00, 0x40, 0x14, 0x54 };
+  if (row > _numlines) {
+    row = _numlines - 1;    // we count rows starting w/0
+  }
 
-	command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
+  command(LCD_SETDDRAMADDR | (col + row_offsets[row]));
 }
 
 // Turn the display on/off (quickly)
 void Adafruit_TinyRGBLCDShield::noDisplay() {
-	_displaycontrol &= ~LCD_DISPLAYON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+  _displaycontrol &= ~LCD_DISPLAYON;
+  command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 void Adafruit_TinyRGBLCDShield::display() {
-	_displaycontrol |= LCD_DISPLAYON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+  _displaycontrol |= LCD_DISPLAYON;
+  command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // Turns the underline cursor on/off
 void Adafruit_TinyRGBLCDShield::noCursor() {
-	_displaycontrol &= ~LCD_CURSORON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+  _displaycontrol &= ~LCD_CURSORON;
+  command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 void Adafruit_TinyRGBLCDShield::cursor() {
-	_displaycontrol |= LCD_CURSORON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+  _displaycontrol |= LCD_CURSORON;
+  command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // Turn on and off the blinking cursor
 void Adafruit_TinyRGBLCDShield::noBlink() {
-	_displaycontrol &= ~LCD_BLINKON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+  _displaycontrol &= ~LCD_BLINKON;
+  command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 void Adafruit_TinyRGBLCDShield::blink() {
-	_displaycontrol |= LCD_BLINKON;
-	command(LCD_DISPLAYCONTROL | _displaycontrol);
+  _displaycontrol |= LCD_BLINKON;
+  command(LCD_DISPLAYCONTROL | _displaycontrol);
 }
 
 // These commands scroll the display without changing the RAM
 void Adafruit_TinyRGBLCDShield::scrollDisplayLeft(void) {
-	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
+  command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVELEFT);
 }
 void Adafruit_TinyRGBLCDShield::scrollDisplayRight(void) {
-	command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
+  command(LCD_CURSORSHIFT | LCD_DISPLAYMOVE | LCD_MOVERIGHT);
 }
 
 // This is for text that flows Left to Right
 void Adafruit_TinyRGBLCDShield::leftToRight(void) {
-	_displaymode |= LCD_ENTRYLEFT;
-	command(LCD_ENTRYMODESET | _displaymode);
+  _displaymode |= LCD_ENTRYLEFT;
+  command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This is for text that flows Right to Left
 void Adafruit_TinyRGBLCDShield::rightToLeft(void) {
-	_displaymode &= ~LCD_ENTRYLEFT;
-	command(LCD_ENTRYMODESET | _displaymode);
+  _displaymode &= ~LCD_ENTRYLEFT;
+  command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This will 'right justify' text from the cursor
 void Adafruit_TinyRGBLCDShield::autoscroll(void) {
-	_displaymode |= LCD_ENTRYSHIFTINCREMENT;
-	command(LCD_ENTRYMODESET | _displaymode);
+  _displaymode |= LCD_ENTRYSHIFTINCREMENT;
+  command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // This will 'left justify' text from the cursor
 void Adafruit_TinyRGBLCDShield::noAutoscroll(void) {
-	_displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
-	command(LCD_ENTRYMODESET | _displaymode);
+  _displaymode &= ~LCD_ENTRYSHIFTINCREMENT;
+  command(LCD_ENTRYMODESET | _displaymode);
 }
 
 // Allows us to fill the first 8 CGRAM locations
 // with custom characters
 void Adafruit_TinyRGBLCDShield::createChar(uint8_t location, uint8_t charmap[]) {
-	location &= 0x7; // we only have 8 locations 0-7
-	command(LCD_SETCGRAMADDR | (location << 3));
-	for (int i = 0; i < 8; i++) {
-		write(charmap[i]);
-	}
-	command(LCD_SETDDRAMADDR);  // unfortunately resets the location to 0,0
+  location &= 0x7; // we only have 8 locations 0-7
+  command(LCD_SETCGRAMADDR | (location << 3));
+  for (int i = 0; i < 8; i++) {
+    write(charmap[i]);
+  }
+  command(LCD_SETDDRAMADDR);  // unfortunately resets the location to 0,0
 }
 
 /*********** mid level commands, for sending data/cmds */
 
 inline void Adafruit_TinyRGBLCDShield::command(uint8_t value) {
-	send(value, LOW);
+  send(value, LOW);
 }
 
 #if ARDUINO >= 100
 inline size_t Adafruit_TinyRGBLCDShield::write(uint8_t value) {
-	send(value, HIGH);
-	return 1;
+  send(value, HIGH);
+  return 1;
 }
 #else
 inline void Adafruit_TinyRGBLCDShield::write(uint8_t value) {
-	send(value, HIGH);
+  send(value, HIGH);
 }
 #endif
 
@@ -321,104 +304,100 @@ inline void Adafruit_TinyRGBLCDShield::write(uint8_t value) {
 
 // little wrapper for i/o writes
 void  Adafruit_TinyRGBLCDShield::_digitalWrite(uint8_t p, uint8_t d) {
-	if (_i2cAddr != 255) {
-		// an i2c command
-		_i2c.digitalWrite(p, d);
-	}
-	else {
-		// straightup IO
-		digitalWrite(p, d);
-	}
+  if (_i2cAddr != 255) {
+    // an i2c command
+    _i2c.digitalWrite(p, d);
+  }
+  else {
+    // straightup IO
+    digitalWrite(p, d);
+  }
 }
 
 // Allows to set the backlight, if the LCD backpack is used
 void Adafruit_TinyRGBLCDShield::setBacklight(uint8_t status) {
-	// check if i2c or SPI
-	_i2c.digitalWrite(8, ~(status >> 2) & 0x1);
-	_i2c.digitalWrite(7, ~(status >> 1) & 0x1);
-	_i2c.digitalWrite(6, ~status & 0x1);
+  // check if i2c or SPI
+  _i2c.digitalWrite(8, ~(status >> 2) & 0x1);
+  _i2c.digitalWrite(7, ~(status >> 1) & 0x1);
+  _i2c.digitalWrite(6, ~status & 0x1);
 }
 
 // little wrapper for i/o directions
 void  Adafruit_TinyRGBLCDShield::_pinMode(uint8_t p, uint8_t d) {
-	if (_i2cAddr != 255) {
-		// an i2c command
-		_i2c.pinMode(p, d);
-	}
-	else {
-		// straightup IO
-		pinMode(p, d);
-	}
+  if (_i2cAddr != 255) {
+    // an i2c command
+    _i2c.pinMode(p, d);
+  }
+  else {
+    // straightup IO
+    pinMode(p, d);
+  }
 }
 
 // write either command or data, with automatic 4/8-bit selection
 void Adafruit_TinyRGBLCDShield::send(uint8_t value, uint8_t mode) {
-	_digitalWrite(_rs_pin, mode);
+  _digitalWrite(_rs_pin, mode);
 
-	// if there is a RW pin indicated, set it low to Write
-	if (_rw_pin != 255) {
-		_digitalWrite(_rw_pin, LOW);
-	}
+  // if there is a RW pin indicated, set it low to Write
+#if defined(LCD_RW)
+  _digitalWrite(_rw_pin, LOW);
+#endif
 
-	if (_displayfunction & LCD_8BITMODE) {
-		write8bits(value);
-	}
-	else {
-		write4bits(value >> 4);
-		write4bits(value);
-	}
+#if defined(LCD_8BIT)
+  write8bits(value);
+#else
+  writeBits(value >> 4);
+  writeBits(value);
+#endif
+
 }
 
-void Adafruit_TinyRGBLCDShield::pulseEnable(void) {
-	_digitalWrite(_enable_pin, LOW);
-	delayMicroseconds(1);
-	_digitalWrite(_enable_pin, HIGH);
-	delayMicroseconds(1);    // enable pulse must be >450ns
-	_digitalWrite(_enable_pin, LOW);
-	delayMicroseconds(100);   // commands need > 37us to settle
-}
+void Adafruit_TinyRGBLCDShield::writeBits(uint8_t value) {
 
-void Adafruit_TinyRGBLCDShield::writeBits(uint8_t value, uint8_t length) {
-	if (length < 8 && _i2cAddr != 255) {
-		uint16_t out = 0;
+#if defined(LCD_8BIT) || defined(LCD_RW_ENABLED)
+  for (int i = 0; i < length; i++) {
+    _pinMode(_data_pins[i], OUTPUT);
+    _digitalWrite(_data_pins[i], (value >> i) & 0x01);
+  }
+  _digitalWrite(_enable_pin, LOW);
+  delayMicroseconds(1);
+  _digitalWrite(_enable_pin, HIGH);
+  delayMicroseconds(1);    // enable pulse must be >450ns
+  _digitalWrite(_enable_pin, LOW);
+  delayMicroseconds(100);   // commands need > 37us to settle
 
-		out = _i2c.readGPIOAB();
+#else
+  uint16_t out = 0;
 
-		// speed up for i2c since its sluggish
-		for (int i = 0; i < 4; i++) {
-			out &= ~_BV(_data_pins[i]);
-			out |= ((value >> i) & 0x1) << _data_pins[i];
-		}
+  out = _i2c.readGPIOAB();
 
-		// make sure enable is low
-		out &= ~_BV(_enable_pin);
+  // speed up for i2c since its sluggish
+  for (int i = 0; i < 4; i++) {
+    out &= ~_BV(_data_pins[i]);
+    out |= ((value >> i) & 0x1) << _data_pins[i];
+  }
 
-		_i2c.writeGPIOAB(out);
+  // make sure enable is low
+  out &= ~_BV(_enable_pin);
+  _i2c.writeGPIOAB(out);
+  delayMicroseconds(1);
 
-		// pulse enable
-		delayMicroseconds(1);
-		out |= _BV(_enable_pin);
-		_i2c.writeGPIOAB(out);
-		delayMicroseconds(1);
-		out &= ~_BV(_enable_pin);
-		_i2c.writeGPIOAB(out);
-		delayMicroseconds(100);
+  out |= _BV(_enable_pin);
+  _i2c.writeGPIOAB(out);
+  delayMicroseconds(1);
 
-	}
-	else {
-		for (int i = 0; i < length; i++) {
-			_pinMode(_data_pins[i], OUTPUT);
-			_digitalWrite(_data_pins[i], (value >> i) & 0x01);
-		}
-		pulseEnable();
-	}
+  out &= ~_BV(_enable_pin);
+  _i2c.writeGPIOAB(out);
+  delayMicroseconds(100);
+#endif
+
 }
 
 uint8_t Adafruit_TinyRGBLCDShield::readButtons(void) {
-	uint8_t reply = 0x1F;
+  uint8_t reply = 0x1F;
 
-	for (uint8_t i = 0; i < 5; i++) {
-		reply &= ~((_i2c.digitalRead(_button_pins[i])) << i);
-	}
-	return reply;
+  for (uint8_t i = 0; i < 5; i++) {
+    reply &= ~((_i2c.digitalRead(_button_pins[i])) << i);
+  }
+  return reply;
 }

--- a/Adafruit_TinyRGBLCDShield.cpp
+++ b/Adafruit_TinyRGBLCDShield.cpp
@@ -55,6 +55,7 @@ Adafruit_TinyRGBLCDShield::Adafruit_TinyRGBLCDShield() {
   _rs_pin = 15;
   _rw_pin = 14;
   _enable_pin = 13;
+
   _data_pins[0] = 12;  // really d4
   _data_pins[1] = 11;  // really d5
   _data_pins[2] = 10;  // really d6
@@ -123,10 +124,9 @@ void Adafruit_TinyRGBLCDShield::begin(uint8_t cols, uint8_t lines, uint8_t dotsi
 
     _i2c.pinMode(_rs_pin, OUTPUT);
     _i2c.pinMode(_enable_pin, OUTPUT);
-    for (uint8_t i=0; i<4; i++) 
-      _i2c.pinMode(_data_pins[i], OUTPUT);
 
     for (uint8_t i=0; i<5; i++) {
+      _i2c.pinMode(_data_pins[i & 0x4], OUTPUT);
       _i2c.pinMode(_button_pins[i], INPUT);
       _i2c.pullUp(_button_pins[i], 1);
     }
@@ -377,8 +377,8 @@ void Adafruit_TinyRGBLCDShield::pulseEnable(void) {
   delayMicroseconds(100);   // commands need > 37us to settle
 }
 
-void Adafruit_TinyRGBLCDShield::write4bits(uint8_t value) {
-  if (_i2cAddr != 255) {
+void Adafruit_TinyRGBLCDShield::writeBits(uint8_t value, uint8_t length) {
+  if (length < 8 && _i2cAddr != 255) {
     uint16_t out = 0;
 
     out = _i2c.readGPIOAB();
@@ -404,21 +404,12 @@ void Adafruit_TinyRGBLCDShield::write4bits(uint8_t value) {
     delayMicroseconds(100);
 
   } else {
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < length; i++) {
      _pinMode(_data_pins[i], OUTPUT);
      _digitalWrite(_data_pins[i], (value >> i) & 0x01);
     }
     pulseEnable();
   }
-}
-
-void Adafruit_TinyRGBLCDShield::write8bits(uint8_t value) {
-  for (int i = 0; i < 8; i++) {
-    _pinMode(_data_pins[i], OUTPUT);
-    _digitalWrite(_data_pins[i], (value >> i) & 0x01);
-  }
-  
-  pulseEnable();
 }
 
 uint8_t Adafruit_TinyRGBLCDShield::readButtons(void) {

--- a/Adafruit_TinyRGBLCDShield.h
+++ b/Adafruit_TinyRGBLCDShield.h
@@ -106,8 +106,7 @@ public:
 
 private:
   void send(uint8_t, uint8_t);
-  void write4bits(uint8_t);
-  void write8bits(uint8_t);
+  void writeBits(uint8_t, uint8_t);
   void pulseEnable();
   void _digitalWrite(uint8_t, uint8_t);
   void _pinMode(uint8_t, uint8_t);
@@ -128,5 +127,8 @@ private:
   uint8_t _i2cAddr;
   Adafruit_TinyMCP23017 _i2c;
 };
+
+#define write4bits(b) writeBits(b, 4)
+#define write8bits(b) writeBits(b, 8)
 
 #endif

--- a/Adafruit_TinyRGBLCDShield.h
+++ b/Adafruit_TinyRGBLCDShield.h
@@ -20,6 +20,7 @@
 #include "Print.h"
 #include "Adafruit_TinyMCP23017.h"
 
+//#define LCD_RW
 // commands
 #define LCD_CLEARDISPLAY 0x01
 #define LCD_RETURNHOME 0x02
@@ -95,19 +96,19 @@ public:
   void setBacklight(uint8_t status); 
 
   void createChar(uint8_t, uint8_t[]);
-  void setCursor(uint8_t, uint8_t); 
+  void setCursor(uint8_t, uint8_t);
+  void command(uint8_t);
+  uint8_t readButtons();
+
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);
 #else
   virtual void write(uint8_t);
 #endif
-  void command(uint8_t);
-  uint8_t readButtons();
 
 private:
   void send(uint8_t, uint8_t);
-  void writeBits(uint8_t, uint8_t);
-  void pulseEnable();
+  void writeBits(uint8_t);
   void _digitalWrite(uint8_t, uint8_t);
   void _pinMode(uint8_t, uint8_t);
 
@@ -127,8 +128,5 @@ private:
   uint8_t _i2cAddr;
   Adafruit_TinyMCP23017 _i2c;
 };
-
-#define write4bits(b) writeBits(b, 4)
-#define write8bits(b) writeBits(b, 8)
 
 #endif

--- a/Adafruit_TinyRGBLCDShield.h
+++ b/Adafruit_TinyRGBLCDShield.h
@@ -18,7 +18,7 @@
 
 #include <inttypes.h>
 #include "Print.h"
-#include <Adafruit_TinyMCP23017.h>
+#include "Adafruit_TinyMCP23017.h"
 
 // commands
 #define LCD_CLEARDISPLAY 0x01

--- a/examples/TinyHelloWorld/TinyHelloWorld.ino
+++ b/examples/TinyHelloWorld/TinyHelloWorld.ino
@@ -9,8 +9,8 @@ When a button is pressed, the backlight changes color.
 
 // include the library code:
 #include <TinyWireM.h>
-#include <Adafruit_TinyMCP23017.h>
-#include <Adafruit_TinyRGBLCDShield.h>
+#include "../../Adafruit_TinyMCP23017.h"
+#include "../../Adafruit_TinyRGBLCDShield.h"
 
 // The shield uses the I2C SCL and SDA pins. On classic Arduinos
 // this is Analog 4 and 5 so you can't use those for analogRead() anymore

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit TinyRGBLCDShield
-version=1.0.0
+version=1.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Adafruit_RGBLCDShield library ported to Trinket/Gemma


### PR DESCRIPTION
I'm trying to build a feed-forward+PID espresso machine based on trinket. The LCD libraries are consuming way too much memory, so I cleaned them up quite a bit. For the shield in question, TinyHelloWorld went from ~4kb to ~3.5kb, just over 14% less with the same behavior.

After this, looking at the USI code and TinyWireM code, I think there's more that can be saved for this tiny processor.
